### PR TITLE
TECH add ipfiltering middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,12 @@ app.use(i18n());
 Accept or reject requests based upon their IP address.
 Controlled by 2 new environment variables
 
-FILTER_IP = true or false (turn it on or off)
-PROTECTED_IPS = SPACE separated list of (a) individual IP addresses (b) IP address ranges
-(c) CIDR blocks
+IP_FILTER_ENABLED = true or false (turn it on or off)
+IP_FILTER_MODE = allow or deny (who to let in or who to shut out)
+IP_FILTER_ALLOWED_IPS = SPACE separated list of (a) individual IP addresses (b) IP address ranges
+(c) CIDR blocks. NOTE: Only works with IP_FILTER_MODE=allow
+IP_FILTER_DENIED_IPS = SPACE separated list of (a) individual IP addresses (b) IP address ranges
+(c) CIDR blocks NOTE: Only works with IP_FILTER_MODE=deny
 
 e.g.
 PROTECTED_IPS=127.0.0.1 127.0.0.2 127.0.0.3,127.0.0.10 127.127.127.0/24
@@ -111,13 +114,14 @@ const ipFilter = require('express-middleware').ipFilter;
 
 const options = {
   ipFilterEnabled: process.env.FILTER_IP === 'true',
-  mode: ['deny'/'allow'],
   log: [false/true],
-  logger: [console.log/logger.debug],
+  logger: logger.debug.bind(logger),
   allowedHeaders: []
 };
 
-app.use(ipFilter(opts));
+if (options.ipFilterEnabled) {
+    app.use(ipFilter(options));
+}
 ```
 
 **Middleware dependency** : _None_

--- a/README.md
+++ b/README.md
@@ -94,6 +94,34 @@ app.use(i18n());
 
 **Middleware dependency** : Language middleware
 
+### IP Filter
+
+Accept or reject requests based upon their IP address.
+Controlled by 2 new environment variables
+
+FILTER_IP = true or false (turn it on or off)
+PROTECTED_IPS = SPACE separated list of (a) individual IP addresses (b) IP address ranges
+(c) CIDR blocks
+
+e.g.
+PROTECTED_IPS=127.0.0.1 127.0.0.2 127.0.0.3,127.0.0.10 127.127.127.0/24
+
+```js
+const ipFilter = require('express-middleware').ipFilter;
+
+const options = {
+  ipFilterEnabled: process.env.FILTER_IP === 'true',
+  mode: ['deny'/'allow'],
+  log: [false/true],
+  logger: [console.log/logger.debug],
+  allowedHeaders: []
+};
+
+app.use(ipFilter(opts));
+```
+
+**Middleware dependency** : _None_
+
 ## Contribute
 
 ```sh

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const jwtToken = require('./src/middleware/jwtToken');
 const sslRedirect = require('./src/middleware/sslRedirect');
 const language = require('./src/middleware/language');
 const i18n = require('./src/middleware/i18n');
+const ipFilter = require('./src/middleware/ipFilter');
 
 module.exports = {
   childLogger,
@@ -15,7 +16,8 @@ module.exports = {
   jwtToken,
   sslRedirect,
   language,
-  i18n
+  i18n,
+  ipFilter
 };
 
 // // //

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "bunyan": "~1.8.1",
     "co-express": "^1.2.2",
     "country-language": "^0.1.7",
-    "http-errors": "1.5.1",
-    "ip": "1.1.4",
+    "http-errors": "^1.5.1",
+    "ip": "^1.1.4",
     "lodash": "~4.11.1",
     "morgan": "~1.7.0",
     "node-uuid": "~1.4.7",
-    "range_check": "1.4.0"
+    "range_check": "^1.4.0"
   },
   "devDependencies": {
     "chai": "~3.5.0",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "bunyan": "~1.8.1",
     "co-express": "^1.2.2",
     "country-language": "^0.1.7",
-    "http-errors": "^1.5.1",
-    "ip": "^1.1.4",
+    "http-errors": "1.5.1",
+    "ip": "1.1.4",
     "lodash": "~4.11.1",
     "morgan": "~1.7.0",
     "node-uuid": "~1.4.7",
-    "range_check": "^1.4.0"
+    "range_check": "1.4.0"
   },
   "devDependencies": {
     "chai": "~3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-middleware",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Set of middlewares for Chauffeur-Privé",
   "keywords": [
     "express",
@@ -14,9 +14,12 @@
     "bunyan": "~1.8.1",
     "co-express": "^1.2.2",
     "country-language": "^0.1.7",
+    "http-errors": "^1.5.1",
+    "ip": "^1.1.4",
     "lodash": "~4.11.1",
     "morgan": "~1.7.0",
-    "node-uuid": "~1.4.7"
+    "node-uuid": "~1.4.7",
+    "range_check": "^1.4.0"
   },
   "devDependencies": {
     "chai": "~3.5.0",

--- a/src/middleware/ipFilter.js
+++ b/src/middleware/ipFilter.js
@@ -38,7 +38,7 @@ function testCidrBlock(ip, constraints, isAllow) {
 /**
  * testRange Test an Explicit IP against an IP address range
  * @param  {String} ip          IP address of caller
- * @param  {Array} constraints  This is a max and min in an Array
+ * @param  {Array} constraints  This is a min and max in an Array
  * @param  {String} isAllow        Is this allow mode
  * @return {Boolean}             True or False, if we should block or allow and matched
  */

--- a/src/middleware/ipFilter.js
+++ b/src/middleware/ipFilter.js
@@ -1,0 +1,195 @@
+'use strict';
+
+module.exports = setup;
+
+const _ = require('lodash');
+const iputil = require('ip');
+const rangeCheck = require('range_check');
+const createError = require('http-errors');
+
+ /**
+  * testExplicitIp Test an Explicit IP against the list of constraints
+  * @param  {String} ip          IP address of caller
+  * @param  {String} constraints IPs to restrict or allow
+  * @param  {String} mode        mode of operation deny/allow
+  * @return {Boolean}             True or False, if we should block or allow and matched
+  */
+function testExplicitIp(ip, constraints, mode) {
+  if (ip === constraints) {
+    return mode === 'allow';
+  }
+  return mode === 'deny';
+}
+
+/**
+ * testCidrBlock Test an Explicit IP against a CIDR subnet mask
+ * @param  {String} ip          IP address of caller
+ * @param  {String} constraints IPs to restrict or allow
+ * @param  {String} mode        mode of operation deny/allow
+ * @return {Boolean}             True or False, if we should block or allow and matched
+ */
+function testCidrBlock(ip, constraints, mode) {
+  if (rangeCheck.inRange(ip, constraints)) {
+    return mode === 'allow';
+  }
+  return mode === 'deny';
+}
+
+/**
+ * testRange Test an Explicit IP against an IP address range
+ * @param  {String} ip          IP address of caller
+ * @param  {Array} constraints  This is a max and min in an Array
+ * @param  {String} mode        mode of operation deny/allow
+ * @return {Boolean}             True or False, if we should block or allow and matched
+ */
+function testRange(ip, constraints, mode) {
+  let withinRange;
+
+  const startIp = iputil.toLong(constraints[0]);
+  const endIp = iputil.toLong(constraints[1]);
+  const longIp = iputil.toLong(ip);
+
+  withinRange = longIp >= startIp && longIp <= endIp;
+
+  if (withinRange === true) {
+    return mode === 'allow';
+  }
+
+  return mode === 'deny';
+}
+
+/**
+ * testIp Test each constraint to see if it's a single IP address, range or block
+ * @param  {String} ip          IP address of caller
+ * @param  {String} mode        mode of operation deny/allow
+ * @return {Boolean}             True or False, if we should block or allow and matched
+ */
+function testIp(ip, mode) {
+  const constraint = this;
+
+  // Check if it is an array or a string
+  if (typeof constraint === 'string') {
+    if (rangeCheck.validRange(constraint)) {
+      return testCidrBlock(ip, constraint, mode);
+    }
+    return testExplicitIp(ip, constraint, mode);
+  }
+  /* istanbul ignore else  */
+  if (typeof constraint === 'object') {
+    return testRange(ip, constraint, mode);
+  }
+}
+
+/**
+ * matchClientIp Match the client IP against any of the constraints
+ * @param  {Array} blockedIps     Full list of all constraints
+ * @param  {String} ip          IP address of caller
+ * @param  {Request} req        The HTTP request
+ * @param  {Object} options        The options for the operation
+ * @return {Boolean}             True or False, if we should block or allow and matched
+ */
+function matchClientIp(blockedIps, ip, req, options) {
+  const mode = options.mode.toLowerCase();
+
+  const result = _.invokeMap(blockedIps, testIp, ip, mode);
+
+  if (mode === 'allow') {
+    return _.some(result);
+  }
+  return _.every(result);
+}
+
+/**
+ * getClientIp Get the client IP address from the incoming call
+ * @param  {Request} req     The HTTP request
+ * @param  {Object} options      The options for the validation, logging etc
+ * @return {String}             Client IP address
+ */
+function getClientIp(req, options) {
+  let ipAddress;
+
+  const headerIp = _.reduce(options.allowedHeaders, (acc, header) => {
+    const testIps = req.headers[header];
+    /* istanbul ignore else  */
+    if (testIps !== '') {
+      acc = testIps;
+    }
+
+    return acc;
+  });
+
+  if (headerIp) {
+    const splitHeaderIp = headerIp.split(',');
+    ipAddress = splitHeaderIp[0];
+  }
+
+  if (!ipAddress) {
+    ipAddress = req.connection.remoteAddress;
+  }
+
+  if (ipAddress.indexOf(':') !== -1 && ipAddress.indexOf('::') === -1) {
+    ipAddress = ipAddress.split(':')[0];
+  }
+
+  return ipAddress;
+}
+
+/**
+ * Verifies if a received IP address is allowed through our system or should be rejected
+ * @param  {Object} opts the middleware options
+ * @return {Function} middleware
+ */
+function setup(opts) {
+  const options = Object.assign({
+    ipFilterEnabled: process.env.FILTER_IP === 'true',
+    mode: 'deny',
+    log: false,
+    logger: null,
+    allowedHeaders: [],
+    allowPrivateIPs: false,
+    excluding: []
+  }, opts);
+
+  /**
+   * The middleware
+   * @param  {Object}   req  Express request
+   * @param  {Object}   res  Express response
+   * @param  {Function} next Express next handler
+   * @returns {void}
+   */
+  return function middleware(req, res, next) {
+    // Are we configured to listen for IPs ?
+    if (options.ipFilterEnabled) {
+      const ip = getClientIp(req, options);
+      // Split the blocked ips by a space and then determine their 'type'
+
+      if (!process.env.PROTECTED_IPS) { return next(); }
+
+      const ipList = process.env.PROTECTED_IPS.split(' ');
+      const blockedIps = _.map(ipList, (e) => {
+        if (e.includes(',') > 0) {
+          const startEnd = e.split(',');
+          return [startEnd[0], startEnd[1]];
+        }
+        return e;
+      });
+
+      if (matchClientIp(blockedIps, ip, req, options)) {
+        // Grant access
+        if (options.log && options.mode !== 'deny') {
+          options.logger(`Access granted to IP address: ${ip}`);
+        }
+
+        return next();
+      }
+
+      // Deny access
+      if (options.log && options.mode !== 'allow') {
+        options.logger(`Access denied to IP address: ${ip}`);
+      }
+
+      throw createError(401, `Access denied to IP address: ${ip}`);
+    }
+    next();
+  };
+}

--- a/test/src/middleware/ipFilter.test.js
+++ b/test/src/middleware/ipFilter.test.js
@@ -6,12 +6,12 @@ const ipFilter = require('../../../src/middleware/ipFilter.js');
 
 describe('No filtering - ipFilter.js', function root() {
   it('should correctly create but do nothing', function test(done) {
-    process.env.FILTER_IP = false;
-    process.env.PROTECTED_IPS = '127.0.0.1';
+    process.env.IP_FILTER_ENABLED = false;
+    process.env.IP_FILTER_DENIED_IPS = '127.0.0.1';
 
     const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
     const res = { set: () => { } };
-    const opts = {};
+    const opts = { };
 
     const middleware = ipFilter(opts);
     expect(middleware).to.be.instanceof(Function);
@@ -22,7 +22,7 @@ describe('No filtering - ipFilter.js', function root() {
 
 describe('deny ip addresses - ipFilter.js', function root() {
   it('should correctly create and be called with no restrictions', function test(done) {
-    process.env.FILTER_IP = false;
+    process.env.IP_FILTER_ENABLED = false;
 
     const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
     const res = { set: () => { } };
@@ -35,8 +35,8 @@ describe('deny ip addresses - ipFilter.js', function root() {
   });
 
   it('should correctly create and be called', function test(done) {
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '';
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_DENIED_IPS = '';
 
     const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
     const res = { set: () => { } };
@@ -49,8 +49,8 @@ describe('deny ip addresses - ipFilter.js', function root() {
   });
 
   it('should not deny the IP', function test(done) {
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.0.0.1';
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_DENIED_IPS = '127.0.0.1';
 
     const req = { get: () => { }, connection: { remoteAddress: '127.0.0.2' } };
     const res = { set: () => { } };
@@ -63,8 +63,8 @@ describe('deny ip addresses - ipFilter.js', function root() {
   });
 
   it('should deny the IP address', function test(done) {
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.0.0.1';
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_DENIED_IPS = '127.0.0.1';
 
     const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
     const res = { set: () => { } };
@@ -81,8 +81,8 @@ describe('deny ip addresses - ipFilter.js', function root() {
   });
 
   it('should deny the ip using a range', function test(done) {
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.127.127.0 127.0.0.1,127.0.0.10';
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_DENIED_IPS = '127.127.127.0 127.0.0.1,127.0.0.10';
 
     const req = { get: () => { }, connection: { remoteAddress: '127.0.0.5' } };
     const res = { set: () => { } };
@@ -98,8 +98,8 @@ describe('deny ip addresses - ipFilter.js', function root() {
   });
 
   it('should deny the ip using a range', function test(done) {
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.127.127.0 127.0.0.1,127.0.0.10';
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_DENIED_IPS = '127.127.127.0 127.0.0.1,127.0.0.10';
 
     const req = { get: () => { }, connection: { remoteAddress: '127.127.0.5' } };
     const res = { set: () => { } };
@@ -115,8 +115,8 @@ describe('deny ip addresses - ipFilter.js', function root() {
   });
 
   it('should deny the ip using a range', function test(done) {
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.127.127.0 127.0.0.1,';
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_DENIED_IPS = '127.127.127.0 127.0.0.1,';
 
     const req = { get: () => { }, connection: { remoteAddress: '127.127.0.5' } };
     const res = { set: () => { } };
@@ -132,12 +132,12 @@ describe('deny ip addresses - ipFilter.js', function root() {
   });
 
   it('should deny CIDR subnet', function test(done) {
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_DENIED_IPS = '127.0.0.1/24';
+
     const req = { get: () => { }, connection: { remoteAddress: '127.0.0.5' } };
     const res = { set: () => { } };
     const opts = { };
-
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.0.0.1/24';
 
     const middleware = ipFilter(opts);
     try {
@@ -151,12 +151,28 @@ describe('deny ip addresses - ipFilter.js', function root() {
 
 describe('allow ip addresses - ipFilter.js', function root() {
   it('should correctly create and be called', function test(done) {
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.0.0.1';
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_ALLOWED_IPS = '127.0.0.1';
+    process.env.IP_FILTER_MODE = 'allow';
 
     const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
     const res = { set: () => { } };
-    const opts = { mode: 'allow' };
+    const opts = { };
+
+    const middleware = ipFilter(opts);
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, res, done);
+  });
+
+  it('should correctly create and be called', function test(done) {
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_MODE = 'allow';
+    delete process.env.IP_FILTER_ALLOWED_IPS;
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
+    const res = { set: () => { } };
+    const opts = { };
 
     const middleware = ipFilter(opts);
     expect(middleware).to.be.instanceof(Function);
@@ -165,12 +181,13 @@ describe('allow ip addresses - ipFilter.js', function root() {
   });
 
   it('should not allow the IP', function test(done) {
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.0.0.1';
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_ALLOWED_IPS = '127.0.0.1';
+    process.env.IP_FILTER_MODE = 'allow';
 
     const req = { get: () => { }, connection: { remoteAddress: '127.0.0.2' } };
     const res = { set: () => { } };
-    const opts = { mode: 'allow' };
+    const opts = { };
 
     try {
       const middleware = ipFilter(opts);
@@ -184,8 +201,9 @@ describe('allow ip addresses - ipFilter.js', function root() {
   });
 
   it('should allow using allowedHeaders', function test(done) {
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.0.0.2';
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_ALLOWED_IPS = '127.0.0.2';
+    process.env.IP_FILTER_MODE = 'allow';
 
     const req = {
       headers: {
@@ -194,7 +212,7 @@ describe('allow ip addresses - ipFilter.js', function root() {
     };
     const res = { set: () => { } };
     /* eslint-disable no-console */
-    const opts = { log: true, logger: console.log, mode: 'allow', allowedHeaders: ['', 'x-forwarded-for'] };
+    const opts = { log: true, logger: console.log, allowedHeaders: ['', 'x-forwarded-for'] };
     /* eslint-enable no-console */
     const middleware = ipFilter(opts);
     expect(middleware).to.be.instanceof(Function);
@@ -203,8 +221,9 @@ describe('allow ip addresses - ipFilter.js', function root() {
   });
 
   it('should allow using allowedHeaders with port', function test(done) {
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.0.0.2';
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_ALLOWED_IPS = '127.0.0.2';
+    process.env.IP_FILTER_MODE = 'allow';
 
     const req = {
       headers: {
@@ -212,7 +231,7 @@ describe('allow ip addresses - ipFilter.js', function root() {
       }
     };
     const res = { set: () => { } };
-    const opts = { mode: 'allow', allowedHeaders: ['', 'x-forwarded-for'] };
+    const opts = { allowedHeaders: ['', 'x-forwarded-for'] };
 
     const middleware = ipFilter(opts);
     expect(middleware).to.be.instanceof(Function);
@@ -221,12 +240,13 @@ describe('allow ip addresses - ipFilter.js', function root() {
   });
 
   it('should allow the IP address', function test(done) {
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.0.0.1';
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_ALLOWED_IPS = '127.0.0.1';
+    process.env.IP_FILTER_MODE = 'allow';
 
     const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
     const res = { set: () => { } };
-    const opts = { mode: 'allow' };
+    const opts = { };
 
     const middleware = ipFilter(opts);
     expect(middleware).to.be.instanceof(Function);
@@ -235,12 +255,13 @@ describe('allow ip addresses - ipFilter.js', function root() {
   });
 
   it('should allow the ip using a range', function test(done) {
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.127.127.0 127.0.0.1,127.0.0.10';
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_ALLOWED_IPS = '127.127.127.0 127.0.0.1,127.0.0.10';
+    process.env.IP_FILTER_MODE = 'allow';
 
     const req = { get: () => { }, connection: { remoteAddress: '127.0.0.5' } };
     const res = { set: () => { } };
-    const opts = { mode: 'allow' };
+    const opts = { };
 
     const middleware = ipFilter(opts);
     expect(middleware).to.be.instanceof(Function);
@@ -249,12 +270,13 @@ describe('allow ip addresses - ipFilter.js', function root() {
   });
 
   it('should allow CIDR subnet', function test(done) {
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_ALLOWED_IPS = '127.0.0.1/24';
+    process.env.IP_FILTER_MODE = 'allow';
+
     const req = { get: () => { }, connection: { remoteAddress: '127.0.0.5' } };
     const res = { set: () => { } };
-    const opts = { mode: 'allow' };
-
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.0.0.1/24';
+    const opts = { };
 
     const middleware = ipFilter(opts);
     expect(middleware).to.be.instanceof(Function);
@@ -263,12 +285,13 @@ describe('allow ip addresses - ipFilter.js', function root() {
   });
 
   it('should allow CIDR subnet', function test(done) {
+    process.env.IP_FILTER_ENABLED = true;
+    process.env.IP_FILTER_ALLOWED_IPS = '127.0.0.1/24';
+    process.env.IP_FILTER_MODE = 'allow';
+
     const req = { get: () => { }, connection: { remoteAddress: '127.127.0.5' } };
     const res = { set: () => { } };
-    const opts = { mode: 'allow' };
-
-    process.env.FILTER_IP = true;
-    process.env.PROTECTED_IPS = '127.0.0.1/24';
+    const opts = { };
 
     try {
       const middleware = ipFilter(opts);

--- a/test/src/middleware/ipFilter.test.js
+++ b/test/src/middleware/ipFilter.test.js
@@ -1,0 +1,283 @@
+'use strict';
+/* eslint no-unused-expressions:0 */
+
+const expect = require('chai').expect;
+const ipFilter = require('../../../src/middleware/ipFilter.js');
+
+describe('No filtering - ipFilter.js', function root() {
+  it('should correctly create but do nothing', function test(done) {
+    process.env.FILTER_IP = false;
+    process.env.PROTECTED_IPS = '127.0.0.1';
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
+    const res = { set: () => { } };
+    const opts = {};
+
+    const middleware = ipFilter(opts);
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, res, done);
+  });
+});
+
+describe('deny ip addresses - ipFilter.js', function root() {
+  it('should correctly create and be called with no restrictions', function test(done) {
+    process.env.FILTER_IP = false;
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
+    const res = { set: () => { } };
+    const opts = { };
+
+    const middleware = ipFilter(opts);
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, res, done);
+  });
+
+  it('should correctly create and be called', function test(done) {
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '';
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
+    const res = { set: () => { } };
+    const opts = {};
+
+    const middleware = ipFilter(opts);
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, res, done);
+  });
+
+  it('should not deny the IP', function test(done) {
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.0.0.1';
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.2' } };
+    const res = { set: () => { } };
+    const opts = { };
+
+    const middleware = ipFilter(opts);
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, res, done);
+  });
+
+  it('should deny the IP address', function test(done) {
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.0.0.1';
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
+    const res = { set: () => { } };
+    /* eslint-disable no-console */
+    const opts = { log: true, logger: console.log };
+    /* eslint-enable no-console */
+    const middleware = ipFilter(opts);
+    try {
+      middleware(req, res, done);
+    } catch (err) {
+      expect(err.message).to.equal('Access denied to IP address: 127.0.0.1');
+      done();
+    }
+  });
+
+  it('should deny the ip using a range', function test(done) {
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.127.127.0 127.0.0.1,127.0.0.10';
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.5' } };
+    const res = { set: () => { } };
+    const opts = { };
+
+    const middleware = ipFilter(opts);
+    try {
+      middleware(req, res, done);
+    } catch (err) {
+      expect(err.message).to.equal('Access denied to IP address: 127.0.0.5');
+      done();
+    }
+  });
+
+  it('should deny the ip using a range', function test(done) {
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.127.127.0 127.0.0.1,127.0.0.10';
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.127.0.5' } };
+    const res = { set: () => { } };
+    const opts = { };
+
+    const middleware = ipFilter(opts);
+    try {
+      middleware(req, res, done);
+    } catch (err) {
+      expect(err.message).to.equal('Access denied to IP address: 127.127.0.5');
+      done();
+    }
+  });
+
+  it('should deny the ip using a range', function test(done) {
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.127.127.0 127.0.0.1,';
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.127.0.5' } };
+    const res = { set: () => { } };
+    const opts = { };
+
+    const middleware = ipFilter(opts);
+    try {
+      middleware(req, res, done);
+    } catch (err) {
+      expect(err.message).to.equal('Access denied to IP address: 127.127.0.5');
+      done();
+    }
+  });
+
+  it('should deny CIDR subnet', function test(done) {
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.5' } };
+    const res = { set: () => { } };
+    const opts = { };
+
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.0.0.1/24';
+
+    const middleware = ipFilter(opts);
+    try {
+      middleware(req, res, done);
+    } catch (err) {
+      expect(err.message).to.equal('Access denied to IP address: 127.0.0.5');
+      done();
+    }
+  });
+});
+
+describe('allow ip addresses - ipFilter.js', function root() {
+  it('should correctly create and be called', function test(done) {
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.0.0.1';
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
+    const res = { set: () => { } };
+    const opts = { mode: 'allow' };
+
+    const middleware = ipFilter(opts);
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, res, done);
+  });
+
+  it('should not allow the IP', function test(done) {
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.0.0.1';
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.2' } };
+    const res = { set: () => { } };
+    const opts = { mode: 'allow' };
+
+    try {
+      const middleware = ipFilter(opts);
+      expect(middleware).to.be.instanceof(Function);
+
+      middleware(req, res, done);
+    } catch (err) {
+      expect(err.message).to.equal('Access denied to IP address: 127.0.0.2');
+      done();
+    }
+  });
+
+  it('should allow using allowedHeaders', function test(done) {
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.0.0.2';
+
+    const req = {
+      headers: {
+        'x-forwarded-for': '127.0.0.2'
+      }
+    };
+    const res = { set: () => { } };
+    /* eslint-disable no-console */
+    const opts = { log: true, logger: console.log, mode: 'allow', allowedHeaders: ['', 'x-forwarded-for'] };
+    /* eslint-enable no-console */
+    const middleware = ipFilter(opts);
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, res, done);
+  });
+
+  it('should allow using allowedHeaders with port', function test(done) {
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.0.0.2';
+
+    const req = {
+      headers: {
+        'x-forwarded-for': '127.0.0.2:84849'
+      }
+    };
+    const res = { set: () => { } };
+    const opts = { mode: 'allow', allowedHeaders: ['', 'x-forwarded-for'] };
+
+    const middleware = ipFilter(opts);
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, res, done);
+  });
+
+  it('should allow the IP address', function test(done) {
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.0.0.1';
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.1' } };
+    const res = { set: () => { } };
+    const opts = { mode: 'allow' };
+
+    const middleware = ipFilter(opts);
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, res, done);
+  });
+
+  it('should allow the ip using a range', function test(done) {
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.127.127.0 127.0.0.1,127.0.0.10';
+
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.5' } };
+    const res = { set: () => { } };
+    const opts = { mode: 'allow' };
+
+    const middleware = ipFilter(opts);
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, res, done);
+  });
+
+  it('should allow CIDR subnet', function test(done) {
+    const req = { get: () => { }, connection: { remoteAddress: '127.0.0.5' } };
+    const res = { set: () => { } };
+    const opts = { mode: 'allow' };
+
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.0.0.1/24';
+
+    const middleware = ipFilter(opts);
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, res, done);
+  });
+
+  it('should allow CIDR subnet', function test(done) {
+    const req = { get: () => { }, connection: { remoteAddress: '127.127.0.5' } };
+    const res = { set: () => { } };
+    const opts = { mode: 'allow' };
+
+    process.env.FILTER_IP = true;
+    process.env.PROTECTED_IPS = '127.0.0.1/24';
+
+    try {
+      const middleware = ipFilter(opts);
+      expect(middleware).to.be.instanceof(Function);
+
+      middleware(req, res, done);
+    } catch (err) {
+      expect(err.message).to.equal('Access denied to IP address: 127.127.0.5');
+      done();
+    }
+  });
+});


### PR DESCRIPTION
Add first IP restriction middleware. Based upon the code from https://www.npmjs.com/package/express-ip-access-control but cleaned up for our use and integration.

Further improvement here will be to use something like a BUS to publish additions or removals of IP addresses deemed good or bad so that all services using the middleware can be brought up to date at the same time and not service by service.

I have a slight concern over IPv6 with this library that I've reused but this is something that should all really be addressed with an IDS. I'm not sure we want to built out this library much more than a 'interim solution'.

1) Validates forwarded from headers
2) Validates against connection.remoteAddress in the http request
3) Allows or denies

Uses lists of IPs, range of IPs, IPs with ports and CIDR blocks.

Uses 2 new environment variables:

FILTER_IP true/false (start checking IP addresses)
PROTECTED_IPS the list of SPACE separated IP addresses to check against (remember this is an allow or deny list)

Examples:
PROTECTED_IPS=127.0.0.1 127.0.0.2,127.0.0.10 127.0.127.0/24

Throws 401 access denied