### PR TITLE
TECH Revert to 1.6.0 and remove extra ids in route monitoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-middleware",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Set of middlewares for Chauffeur-Privé",
   "keywords": [
     "express",
@@ -9,30 +9,29 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "@chauffeur-prive/i18n": "1.2.0",
-    "accept-language-parser": "1.3.0",
-    "bunyan": "1.8.1",
-    "co-express": "1.2.2",
-    "country-language": "0.1.7",
-    "eslint-config-cp": "github:transcovo/eslint-config-cp#1.1.0",
+    "@chauffeur-prive/i18n": "^1.2.0",
+    "accept-language-parser": "^1.3.0",
+    "bunyan": "~1.8.1",
+    "co-express": "^1.2.2",
+    "country-language": "^0.1.7",
     "http-errors": "1.5.1",
     "ipaddr.js": "1.2.0",
-    "lodash": "4.11.1",
-    "morgan": "1.7.0",
-    "uuid": "3.0.1"
+    "lodash": "~4.11.1",
+    "morgan": "~1.7.0",
+    "node-uuid": "~1.4.7"
   },
   "devDependencies": {
-    "chai": "3.5.0",
-    "co-mocha": "1.1.2",
-    "coveralls": "2.11.6",
-    "eslint": "1.10.3",
+    "chai": "~3.5.0",
+    "co-mocha": "~1.1.2",
+    "coveralls": "~2.11.6",
+    "eslint": "~1.10.3",
     "eslint-config-cp": "transcovo/eslint-config-cp#1.1.0",
-    "express": "4.14.0",
-    "istanbul": "0.4.2",
-    "mocha": "2.4.5",
-    "mocha-lcov-reporter": "1.0.0",
-    "sinon": "1.17.3",
-    "supertest": "2.0.1"
+    "express": "^4.14.0",
+    "istanbul": "~0.4.2",
+    "mocha": "~2.4.5",
+    "mocha-lcov-reporter": "~1.0.0",
+    "sinon": "~1.17.3",
+    "supertest": "^2.0.1"
   },
   "scripts": {
     "test": "npm run lint && npm run coverage",

--- a/src/middleware/requestId.js
+++ b/src/middleware/requestId.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uuid = require('uuid');
+const uuid = require('node-uuid');
 
 module.exports = setup;
 


### PR DESCRIPTION
### Description:

Remove the dependencies freeze due to incompatibilities in other applications.
