### PR TITLE
TECH Update requestId behaviour

### DIFF
--- a/src/middleware/childLogger.js
+++ b/src/middleware/childLogger.js
@@ -24,7 +24,7 @@ function setup(logger) {
    * @returns {void}
    */
   return function middleware(req, res, next) {
-    req.logger = logger.child({ requestId: req.requestId });
+    req.logger = logger.child({ requestId: req.requestId, requestPath: req.requestPath });
     next();
   };
 }

--- a/src/middleware/requestId.js
+++ b/src/middleware/requestId.js
@@ -10,7 +10,7 @@ module.exports = setup;
  * When the id in request url is equal to 'me', then the id is replaced by the authenticated user's id
  * @return {Function} middleware
  */
-function setup() {
+function setup(name = 'unknown') {
   /**
    * Middleware
    * @param  {Object}   req  Express request
@@ -20,15 +20,23 @@ function setup() {
    */
   return function middleware(req, res, next) {
     let requestId = req.get('x-request-id');
+    let requestPath = req.get('x-request-path');
 
-    if (requestId) {
-      requestId += `.${uuid.v4()}`;
-    } else {
+    if (!requestId) {
       requestId = uuid.v4();
+    }
+
+    if (requestPath) {
+      requestPath += `.${name}`;
+    } else {
+      requestPath = name;
     }
 
     res.set('x-request-id', requestId);
     req.requestId = requestId;
+
+    res.set('x-request-path', requestPath);
+    req.requestPath = requestPath;
 
     next();
   };

--- a/test/src/middleware/childLogger.test.js
+++ b/test/src/middleware/childLogger.test.js
@@ -21,7 +21,7 @@ describe('child logger middleware - childLogger.js', function root() {
     middleware(req, null, () => {
       childSpy.calledOnce;
       expect(childSpy.args[0].length).to.equal(1);
-      expect(childSpy.args[0][0]).to.deep.equal({ requestId: '110e8400-e29b-11d4-a716-446655440000' });
+      expect(childSpy.args[0][0]).to.deep.equal({ requestId: '110e8400-e29b-11d4-a716-446655440000', requestPath: undefined });
       done();
     });
   });
@@ -37,7 +37,7 @@ describe('child logger middleware - childLogger.js', function root() {
     middleware(req, null, () => {
       childSpy.calledOnce;
       expect(childSpy.args[0].length).to.equal(1);
-      expect(childSpy.args[0][0]).to.deep.equal({ requestId: undefined });
+      expect(childSpy.args[0][0]).to.deep.equal({ requestId: undefined, requestPath: undefined });
       done();
     });
   });

--- a/test/src/middleware/requestId.test.js
+++ b/test/src/middleware/requestId.test.js
@@ -37,7 +37,7 @@ describe('request id middleware - requestId.js', function root() {
     expect(req.requestId).to.equal(args[1]);
   });
 
-  it('should concate a new id to the current x-request-id header', function test() {
+  it('should forward the current x-request-id header', function test() {
     const currentReqId = '6ca66f56-dec4-45dd-9dd0-fd1fe6806b18';
     const req = { get: () => currentReqId };
     const res = { set: () => { } };
@@ -54,8 +54,64 @@ describe('request id middleware - requestId.js', function root() {
     const args = setSpy.args[0];
     expect(args.length).to.equal(2);
     expect(args[0]).to.equal('x-request-id');
-    expect(args[1]).to.match(new RegExp(`^${currentReqId}\.[0-9a-f-]+$`));
+    expect(args[1]).to.equal(currentReqId);
 
     expect(req.requestId).to.equal(args[1]);
+  });
+
+  it('should forward the current x-request-path header value and append the current microservice name', function test() {
+    const header = { 'x-request-path': 'micro-service-1' };
+    const req = { get: (val) => header[val] };
+    const res = { set: () => { } };
+
+    const getSpy = sinon.spy(req, 'get');
+    const setSpy = sinon.spy(res, 'set');
+
+    const name = 'micro-service-2';
+    const middleware = requestId(name);
+
+    middleware(req, res, () => {});
+
+    getSpy.withArgs('x-request-path').calledOnce;
+    setSpy.calledOnce;
+    expect(setSpy.args[1]).to.deep.equal(['x-request-path', 'micro-service-1.micro-service-2']);
+    expect(req.requestPath).to.equal('micro-service-1.micro-service-2');
+  });
+
+  it('should forward the current x-request-path header value and append the current microservice name', function test() {
+    const header = { 'x-request-path': 'micro-service-1' };
+    const req = { get: (val) => header[val] };
+    const res = { set: () => { } };
+
+    const getSpy = sinon.spy(req, 'get');
+    const setSpy = sinon.spy(res, 'set');
+
+    const name = 'micro-service-2';
+    const middleware = requestId(name);
+
+    middleware(req, res, () => {});
+
+    getSpy.withArgs('x-request-path').calledOnce;
+    setSpy.calledOnce;
+    expect(setSpy.args[1]).to.deep.equal(['x-request-path', 'micro-service-1.micro-service-2']);
+    expect(req.requestPath).to.equal('micro-service-1.micro-service-2');
+  });
+
+  it('should forward the current x-request-path header value and append unknown if name is not defined', function test() {
+    const header = { 'x-request-path': 'micro-service-1' };
+    const req = { get: (val) => header[val] };
+    const res = { set: () => { } };
+
+    const getSpy = sinon.spy(req, 'get');
+    const setSpy = sinon.spy(res, 'set');
+
+    const middleware = requestId();
+
+    middleware(req, res, () => {});
+
+    getSpy.withArgs('x-request-path').calledOnce;
+    setSpy.calledOnce;
+    expect(setSpy.args[1]).to.deep.equal(['x-request-path', 'micro-service-1.unknown']);
+    expect(req.requestPath).to.equal('micro-service-1.unknown');
   });
 });


### PR DESCRIPTION

### Description:
Use the HTTP header in the request to transfer information regarding the transaction: 
'x-request-id': is a correlationId which will remain the same upon microservices for the same transaction. 
'x-request-path': contain the transaction path. Each microservice appends its name to this field.

Those two fields will be logged automatically in the child logger. (stored in the req param)


### Coverage result:
```
=============================== Coverage summary ===============================
Statements   : 100% ( 177/177 )
Branches     : 100% ( 51/51 )
Functions    : 100% ( 28/28 )
Lines        : 100% ( 172/172 )
================================================================================
```

### Linked PRs:
