### PR TITLE
TECH Fix Language Middleware, add unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-middleware",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Set of middlewares for Chauffeur-Privé",
   "keywords": [
     "express",

--- a/src/middleware/language.js
+++ b/src/middleware/language.js
@@ -39,7 +39,7 @@ function findExactLanguageMatch(languages, parsedLanguages) {
       }
       return matchingLanguage;
     });
-  return matchingLanguage ? languageObjectToString(matchingLanguage) : null;
+  return matchingLanguage || null;
 }
 
 /**

--- a/test/src/middleware/language.test.js
+++ b/test/src/middleware/language.test.js
@@ -79,6 +79,30 @@ describe('language middleware - language.js', function root() {
     });
   });
 
+  it('should match exactly the first language found in the Accept-Language header', function test(done) {
+    const req = { get: () => 'fr-FR,en-US;q=0.7' };
+
+    const middleware = language({ languages });
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, null, () => {
+      expect(req.language).to.equal('fr-FR');
+      done();
+    });
+  });
+
+  it('should match the first language found with a partial matching', function test(done) {
+    const req = { get: () => 'fr,en-US;q=0.7' };
+
+    const middleware = language({ languages });
+    expect(middleware).to.be.instanceof(Function);
+
+    middleware(req, null, () => {
+      expect(req.language).to.equal('fr-FR');
+      done();
+    });
+  });
+
   it('should throw if languages is not set', function test() {
     expect(() => language({ languages: null })).to.throw();
   });


### PR DESCRIPTION

### Description:

findExactLanguageMatch() was always returning null.

### Coverage result:
```
=============================== Coverage summary ===============================
Statements   :
Branches     :
Functions    :
Lines        :
================================================================================
```

### Linked PRs:
