### PR TITLE
TECH updated lodash to the closest patch resolving vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-middleware",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Set of middlewares for Chauffeur-Privé",
   "keywords": [
     "express",
@@ -16,7 +16,7 @@
     "country-language": "0.1.7",
     "http-errors": "1.5.1",
     "ipaddr.js": "1.2.0",
-    "lodash": "4.17.5",
+    "lodash": "4.17.12",
     "morgan": "1.9.1",
     "node-uuid": "1.4.7"
   },


### PR DESCRIPTION
### Description:
In the context of https://github.com/transcovo/compass/pull/123, I'm bumping a patch of lodash in express-middleware so I can use this new version in compass to resolve a couple of vulnerabilities introduced by the lodash version express-middleware uses

### Coverage result:
```
=============================== Coverage summary ===============================
Statements   :
Branches     :
Functions    :
Lines        :
================================================================================
```

### Linked PRs:
- https://github.com/transcovo/compass/pull/123